### PR TITLE
Python3.8fix multiprocessing work around

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Topic :: Scientific/Engineering :: Bio-Informatics"
     ],
-    python_requires=">=3.6,<3.8",
+    python_requires=">=3.6,<3.9",
     install_requires=[
         "pandas",
         "pyranges",

--- a/src/talon/talon.py
+++ b/src/talon/talon.py
@@ -32,6 +32,12 @@ from . import process_sams as procsams
 from . import query_utils as qutils
 from . import transcript_utils as tutils
 
+# fix to maintain multiprocessing similar to python 3.7
+# see https://github.com/deeptools/HiCExplorer/issues/628
+# and https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/
+if not mp.get_start_method(allow_none=True):
+    mp.set_start_method('fork')
+
 # set verbosity for pysam
 save = pysam.set_verbosity(0)
 # pysam.set_verbosity(save)


### PR DESCRIPTION
Thank you to the authors for their work on this tool.

I found a workaround that allows the multiprocessing as written to work on Python versions later than 3.7.
By setting:
 `mp.set_start_method('fork')`
we can override the new default on some systems to use the `spawn` method

See these for references on the issue:
https://github.com/deeptools/HiCExplorer/issues/628
https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/

Since Python 3.7 is now officially depreciated, it is necessary to support more recent versions of python.

I have not tested this modification on versions newer than 3.8, but I would expect it to work.

I only bumped the required python version to a max of 3.8 but we can modify that when we confirm that additional versions are working.

This should fix this posted issue:
https://github.com/mortazavilab/TALON/issues/137